### PR TITLE
fix minor formatting differences

### DIFF
--- a/day_1.md
+++ b/day_1.md
@@ -87,13 +87,13 @@ Although practicality beats purity.
 Errors should never pass silently.
 Unless explicitly silenced.
 In the face of ambiguity, refuse the temptation to guess.
-There should be one, and preferably only one, obvious way to do it.
-Although that way may not be obvious at first unless you're Dutch.>
+There should be one-- and preferably only one --obvious way to do it.
+Although that way may not be obvious at first unless you're Dutch.
 Now is better than never.
-Although never is often better than right now.
+Although never is often better than *right* now.
 If the implementation is hard to explain, it's a bad idea.
 If the implementation is easy to explain, it may be a good idea.
-Namespaces are one honking great idea... let's do more of those!
+Namespaces are one honking great idea -- let's do more of those!
 ```
 
 You can check them out, only running python on the console and then


### PR DESCRIPTION
The Zen of Python is formatted a bit differnetly than what you get with "import this"
(I did a deep dive on it, it seems it hasn´t changed since 1999, see: https://peps.python.org/pep-0020/ and https://groups.google.com/g/comp.lang.python/c/B_VxeTBClM0/m/L8W9KlsiriUJ)
