### PR TITLE
corrects type constraints for dictionary keys

### DIFF
--- a/day_3.md
+++ b/day_3.md
@@ -754,7 +754,8 @@ By the way, [here](https://www.w3schools.com/python/python_sets_methods.asp) is 
 ## Dictionaries
 
 Dictionaries are used to store data values in key:value pairs.
-The key name of a dictionary must be always a string.
+The key name of a dictionary must be always of an immutable type (string, boolean, int, float, complex, tuple, frozenset). If it is a collection (tuple, frozenset), all elements inside must also be immutable.
+
 
 ```python
 a_dict = {
@@ -853,6 +854,7 @@ dict_values(['Pearl Jam', 'guitar', 10, True])
 
 By the way, [here](https://www.w3schools.com/python/python_dictionaries_methods.asp) is the list of dicts methods, which are many and pretty self explanatory.
 
+More about mutable vs immutable types [here|https://www.pythontutorial.net/advanced-python/python-mutable-and-immutable/]
 ___
 
 [Go to Day 4](day_4.md)


### PR DESCRIPTION
I didn´t want to overcomplicate the examples, perhaps we could add a more complex example at the end (with several types of keys, a nested dict, etc)